### PR TITLE
Just hack it for now

### DIFF
--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -12,18 +12,7 @@
 #[doc(hidden)]
 macro_rules! __unless_target_features {
     ($($tf:tt),+ => $body:expr ) => {{
-        #[cfg(not(all($(target_feature=$tf,)*)))]
-        {
-            #[cfg(not(target_env = "sgx"))]
-            $body
-
-            // CPUID is not available on SGX targets
-            #[cfg(target_env = "sgx")]
-            false
-        }
-
-        #[cfg(all($(target_feature=$tf,)*))]
-        true
+        cfg!((all($(target_feature=$tf,)*)))
     }};
 }
 


### PR DESCRIPTION
There is currently a bug in `cargo` feature unification [when using `resolver = 2`](
https://doc.rust-lang.org/cargo/reference/resolver.html#feature-resolver-version-2) and a target-specific include. Inside `sha2`, `cpufeatures` is included with [the following lines](https://github.com/RustCrypto/hashes/blob/5f9d064c0995047d06bc4e7e56422e6eaf31ac3b/sha1/Cargo.toml#L24)

```
[target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
cpufeatures = "0.1.5"
```

When the `mc-consensus-enclave-trusted` crate includes it in order to add features you would expect this to add the unified feature:

```
cpufeatures = { version = "0.1.5", features = ["compile-only"] }
```

Unfortunately, this feature is not actually added to the target-specific dependency in `sha2`. Similarly, when the enclave uses this:

```
[target.'cfg(any(target_arch = "aarch64", target_arch = "x86_64", target_arch = "x86"))'.dependencies]
cpufeatures = { version = "0.1.5", features = ["compile-only"] }
```

The feature is *also* not added to the version of `cpufeatures` built for `sha2`. I believe this is a bug, and will be forwarding upstream, as well as conducting other tests (so we don't have to maintain a `cpufeatures` fork forever), but since we're only patching in the new cpufeatures in the enclave (now), we can just unconditionally return whether all the target features are enabled.