### PR TITLE
Fix the fix

### DIFF
--- a/cpufeatures/src/x86.rs
+++ b/cpufeatures/src/x86.rs
@@ -12,7 +12,7 @@
 #[doc(hidden)]
 macro_rules! __unless_target_features {
     ($($tf:tt),+ => $body:expr ) => {{
-        cfg!((all($(target_feature=$tf,)*)))
+        cfg!(all($(target_feature=$tf,)*))
     }};
 }
 


### PR DESCRIPTION
Rust doesn't like spurious parens inside the cfg macro.